### PR TITLE
add wd outputs, annual summaries

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -15,8 +15,9 @@ typedef struct
   //-----------------------------------
   int simtype;                   //simulation type; 1=surveys,2=tides,3=days,4=full year
   int n;                         //number of rows in driver data; represents surveys, tides, or days
-  int simtimestep;               //timestep_interval   (in minutes)
-  int constrain_daylight;        //constrain_daylight  (Bool is int; TRUE 0=yes, FALSE 1=no)
+  int simtimestep;               //timestep_interval    (in minutes)
+  int constrain_daylight;        //constrain_daylight   (Bool is int; TRUE 0=yes, FALSE 1=no)
+  int save_waterdepth;           //save water depths? (Bool is int; TRUE 0=yes, FALSE 1=no)
   double lowerbound_waterwindow; //lower bound in water window to estimate availability (negative is water)
   double upperbound_waterwindow; //upper bound in water window to estimate availability (positive is dry)
   int usemask;                   //use ascii mask for field summaries (Bool is int; TRUE 0=yes, FALSE 1=no)

--- a/include/timsa.h
+++ b/include/timsa.h
@@ -33,6 +33,7 @@ extern void iterateday(Config);
 extern void tide_wdchange(Raster *, double *[], int, int, int, int, int);
 extern int  check_nodata(Raster *, int *[], double *[], double *[], int, int, int);
 extern void writeindices(Config *, Raster *, Raster *, int, int, int);
+extern void writesumy(Config);
 
 /* Definition of macros */
 

--- a/src/functions/Makefile
+++ b/src/functions/Makefile
@@ -9,7 +9,7 @@
 include ../../Makefile.inc
 
 OBJ	= check_nodata.$O fail.$O fnraster.$O fncsv.$O fscanconfig.$O iterateday.$O iteratesurvey.$O tide_wdchange.$O\
-	  writeindices.$O
+	  writeindices.$O writesumy.$O
 
 INC	= ../../include
 LIB	= ../../lib/libfunctions.$A

--- a/src/functions/fscanconfig.c
+++ b/src/functions/fscanconfig.c
@@ -44,6 +44,7 @@ Bool fscanconfig(Config *config,       /* timsa configuration         */
   if((read = getline(&buffer, &len, fp)) != -1) config->n                  = (int)strtol(buffer, &ptr, 10);
   if((read = getline(&buffer, &len, fp)) != -1) config->simtimestep        = (int)strtol(buffer, &ptr, 10);
   if((read = getline(&buffer, &len, fp)) != -1) config->constrain_daylight = (int)strtol(buffer, &ptr, 10);
+  if((read = getline(&buffer, &len, fp)) != -1) config->save_waterdepth    = (int)strtol(buffer, &ptr, 10);
   if((read = getline(&buffer, &len, fp)) != -1) config->lowerbound_waterwindow = (double)strtod(buffer, &ptr);
   if((read = getline(&buffer, &len, fp)) != -1) config->upperbound_waterwindow = (double)strtod(buffer, &ptr);
   if((read = getline(&buffer, &len, fp)) != -1) config->usemask                  = (int)strtol(buffer, &ptr, 10);

--- a/src/functions/iterateday.c
+++ b/src/functions/iterateday.c
@@ -360,6 +360,12 @@ void iterateday(Config config){ //userinputs
       }
 
   }//..end of day loop
+
+  //----------------------------------
+  // write day average summary raster
+  //----------------------------------
+  writesumy(config);
+
   //----------------
   //free memory
   //----------------

--- a/src/functions/writesumy.c
+++ b/src/functions/writesumy.c
@@ -1,0 +1,63 @@
+/*===============================================================*/
+/*                                                               */
+/* writesumy.c                                                   */
+/*   create average raster from input folder                     */
+/*                                                               */
+/*===============================================================*/
+
+/* Standard C header files */
+#include <stdlib.h>
+#include <stdio.h>
+#include <math.h>
+#include <string.h>
+#include <errno.h>
+
+/* TIMSA C header files */
+#include "timsa.h"
+#include "fnraster.h"
+
+void writesumy(Config config){ //userinputs
+  Raster *rget,*ravg;
+  char fname[120];
+  int i,j;
+
+  for( i=0; i < config.n; i++){
+    //get data for day
+    if(config.constrain_daylight == TRUE){
+      sprintf(fname, "%s/day_%03d_daylightonly_swa.asc",config.shallowwateravail_outdir,i);
+    }else{
+      sprintf(fname, "%s/day_%03d_daynight_swa.asc",config.shallowwateravail_outdir,i);
+    }
+    rget = rasterget(fname);    
+
+    //make empty raster for averages
+    if(i==0){
+      ravg = rastercopy(rget);
+      for(j = 0; j < ravg->count; j++){
+        if(ravg->data[j] != ravg->nodata){ ravg->data[j] = 0.0;}
+      }
+    }
+
+    //..............
+    // sum data
+    //..............
+    for(j=0; j < ravg->count; j++){
+      if(ravg->data[j] != ravg->nodata){ ravg->data[j] += rget->data[j];}
+    }    
+  }//..end get data all N
+
+  //get average for all N by dividing by N
+  for(j=0; j < ravg->count; j++){
+    if(ravg->data[j] != ravg->nodata){ ravg->data[j] /= config.n;}
+  }
+
+  //save raster to file
+  if(config.constrain_daylight == TRUE){
+    sprintf(fname, "%s/dayavg_daylightonly_swa.asc",config.shallowwateravail_outdir);
+  }else{
+    sprintf(fname, "%s/dayavg_daynight_swa.asc",config.shallowwateravail_outdir);
+  }
+  rasterwrite(ravg,fname);
+  
+  //done
+}

--- a/timsa_drivers.conf
+++ b/timsa_drivers.conf
@@ -11,38 +11,39 @@
   /*-----------------------------------*/
   /* additional options in config file */
   /*-----------------------------------*/
-  3    /* (integer) simulation type; 1=surveys,2=tides,3=days,4=full year */
-  366    /* (integer) number of rows in driver data; represents surveys, tides, or days */
-  5    /* (integer) timestep_interval   (in minutes) */
-  0    /* (integer) constrain_daylight  (Bool is int; TRUE 0=yes, FALSE 1=no) */
-  -0.5 /* (double)  lower bound in water window to estimate availability (negative is water) */
-  0.5  /* (double)  upper bound in water window to estimate availability (positive is dry) */
-  1    /* (inteter) use ascii mask for field summaries (Bool is int; TRUE 0=yes, FALSE 1=no) */
-  ./waterraster_big.asc     /* (string) ascii map 0 exclude 1 include; dummy name if usemask is false */
+  3     /* (integer) simulation type; 1=surveys,2=tides,3=days,4=full year */
+  365   /* (integer) number of rows in driver data; represents surveys, tides, or days */
+  1     /* (integer) timestep_interval   (in minutes) */
+  0     /* (integer) constrain_daylight  (Bool is int; TRUE 0=yes, FALSE 1=no) */
+  0     /* (integer) save water depths every 10 min (Bool is int; TRUE=yes, FALSE 1=no) */
+  -0.55 /* (double)  lower bound in water window to estimate availability (negative is water) */
+  0.45  /* (double)  upper bound in water window to estimate availability (positive is dry) */
+  1     /* (inteter) use ascii mask for field summaries (Bool is int; TRUE 0=yes, FALSE 1=no) */
+  /PATH/TO/MASK/studyarea_mllw_10m.asc     /* (string) ascii map 0 exclude 1 include; dummy name if usemask is false */
 
   /*------------------*/
   /* filepath outputs */
   /*------------------*/
-  ./outputs/          /* (string) output location for shallow water availability estimates (in minutes) */
-  ./outputs/         /* (string) OPTIONAL, but must have dummy path output location for simulated water depts, every 30 minutes (meters) */
+  /PATH/TO/OUTPUT/     /* (string) output location for shallow water availability estimates (in minutes) */
+  /PATH/TO/OUTPUT/     /* (string) OPTIONAL, but must have dummy path output location for simulated water depts, every 30 minutes (meters) */
 
   /*------------------*/
   /* filepaths inputs */
   /*------------------*/
-  ./waterraster_big.asc   /* (string) water map */
-  ./gaugeraster_big.asc   /* (string) tide gauge map */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_sun.csv /* (string) sunrise sunset times */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_survey_dummy.csv /* (string) survey times */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_1st_LT.csv  /* (string) low tide times for 1st tide */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_2nd_LT.csv  /* (string) low tide times for 2nd tide */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_1st_HGT_Xneg1.csv  /* (string) low tide heights 1st tide */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_2nd_HGT_Xneg1.csv  /* (string) low tide heights for 2nd tide */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_1st_Period_Ebb.csv  /* (string) period length for 1st ebb tide */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_2nd_Period_Ebb.csv  /* (string) period length for 2nd ebb tide */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_1st_Period_Flood.csv  /* (string) period length for 1st flood tide */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_2nd_Period_Flood.csv  /* (string) period length for 2nd flodd tide */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_1st_TR_Ebb.csv  /* (string) tidal range for 1st ebb tide */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_2nd_TR_Ebb.csv  /* (string) tidal range for 2nd ebb tide */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_1st_TR_Flood.csv  /* (string) tidal range for 1st flood tide */
-  ../../RESEARCH/COLLABORATIONS/martinez_marisa/2016_timsa_files/2016_2nd_TR_Flood.csv  /* (string) tidal range for 2nd flodd tide */
+  /PATH/TO/MLLW/studyarea_mllw_10m.asc   /* (string) water map */
+  /PATH/TO/GAUGEMAP/gauge_reference.asc    /* (string) tide gauge map */
+  /PATH/TO/CSVDATA/2016_sun.csv /* (string) sunrise sunset times */
+  /PATH/TO/CSVDATA/2016_survtimes.csv /* (string) survey times */
+  /PATH/TO/CSVDATA/2016_1st_LT.csv  /* (string) low tide times for 1st tide */
+  /PATH/TO/CSVDATA/2016_2nd_LT.csv  /* (string) low tide times for 2nd tide */
+  /PATH/TO/CSVDATA/2016_1st_HGT_Xneg1.csv  /* (string) low tide heights 1st tide */
+  /PATH/TO/CSVDATA/2016_2nd_HGT_Xneg1.csv  /* (string) low tide heights for 2nd tide */
+  /PATH/TO/CSVDATA/2016_1st_Period_Ebb.csv  /* (string) period length for 1st ebb tide */
+  /PATH/TO/CSVDATA/2016_2nd_Period_Ebb.csv  /* (string) period length for 2nd ebb tide */
+  /PATH/TO/CSVDATA/2016_1st_Period_Flood.csv  /* (string) period length for 1st flood tide */
+  /PATH/TO/CSVDATA/2016_2nd_Period_Flood.csv  /* (string) period length for 2nd flodd tide */
+  /PATH/TO/CSVDATA/2016_1st_TR_Ebb.csv  /* (string) tidal range for 1st ebb tide */
+  /PATH/TO/CSVDATA/2016_2nd_TR_Ebb.csv  /* (string) tidal range for 2nd ebb tide */
+  /PATH/TO/CSVDATA/2016_1st_TR_Flood.csv  /* (string) tidal range for 1st flood tide */
+  /PATH/TO/CSVDATA/2016_2nd_TR_Flood.csv  /* (string) tidal range for 2nd flodd tide */
 


### PR DESCRIPTION
added option to save simulated water depth output every 10 simulated minutes -- works only for the survey tidal simulations.

added, by default, are day-averaged maps when simulating tides for multiple days. this can be useful for evaluating the average shallow-water availability for all days over a month, breeding period, season, or entire year.  